### PR TITLE
Added test for enabling namespace auto-import

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -227,6 +227,7 @@ jobs:
             /workdir/e2e/unit_tests/turtles_operator.spec.ts
             /workdir/e2e/unit_tests/turtles_plugin.spec.ts
             /workdir/e2e/unit_tests/menu.spec.ts
+            /workdir/e2e/unit_tests/namespace.spec.ts
           UI_ACCOUNT: ${{ inputs.ui_account }}
           UPGRADE_OS_CHANNEL: ${{ inputs.upgrade_os_channel }}
         run: cd tests && make start-cypress-tests

--- a/tests/cypress/latest/e2e/unit_tests/namespace.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/namespace.spec.ts
@@ -35,7 +35,7 @@ describe('Namespace testing', () => {
         .type('Project: Default{enter}{esc}');
       cy.get('.outlet').contains('CAPI Auto-Import');
 
-      // Reload required
+      // Reload required since kebab menu icon not clickable
       cy.reload();
       cy.getBySel('sortable-table-0-action-button').click();
       cy.contains('Enable CAPI Auto-Import')

--- a/tests/cypress/latest/e2e/unit_tests/namespace.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/namespace.spec.ts
@@ -1,0 +1,50 @@
+/*
+Copyright © 2022 - 2023 SUSE LLC
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import '~/support/commands';
+import * as cypressLib from '@rancher-ecp-qa/cypress-library';
+import { qase } from 'cypress-qase-reporter/dist/mocha';
+
+Cypress.config();
+describe('Namespace testing', () => {
+  beforeEach(() => {
+    cy.login();
+    cy.visit('/');
+    cypressLib.burgerMenuToggle();
+  });
+
+  qase(4,
+    it('Enable namespace auto-import', () => {
+      cy.contains('local')
+        .click();
+      cypressLib.accesMenu('Projects/Namespaces');
+
+      // Select default namespace
+      cy.contains('Only User Namespaces') // eslint-disable-line cypress/unsafe-to-chain-command
+        .click()
+        .type('Project: Default{enter}{esc}');
+      cy.get('.outlet').contains('CAPI Auto-Import');
+
+      // Reload required
+      cy.reload();
+      cy.getBySel('sortable-table-0-action-button').click();
+      cy.contains('Enable CAPI Auto-Import')
+        .click();
+
+      cy.getBySel('namespaces-values').click();
+      cy.contains('Only User Namespaces')
+        .click();
+
+    })
+  );
+});


### PR DESCRIPTION
PR adds test scenario for checking and enabling default namespace CAPI auto-import
Verification run: https://github.com/rancher-sandbox/rancher-turtles-e2e/actions/runs/7186100168/job/19570797884