### PR TITLE
Update namespace test for v2.7

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/namespace.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/namespace.spec.ts
@@ -33,7 +33,9 @@ describe('Namespace testing', () => {
       cy.contains('Only User Namespaces') // eslint-disable-line cypress/unsafe-to-chain-command
         .click()
         .type('Project: Default{enter}{esc}');
-      cy.get('.outlet').contains('CAPI Auto-Import');
+
+      // Commenting till capi-ui-extension/issues/17 is fixed
+      // cy.get('.outlet').contains('CAPI Auto-Import');
 
       // Reload required since kebab menu icon not clickable
       cy.reload();


### PR DESCRIPTION
### What does this PR do?
Disabling a check due to bug in Rancher 2.7

