### PR TITLE
Fleet namespace CI fix

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/capd_cluster.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capd_cluster.spec.ts
@@ -36,9 +36,11 @@ describe('Import CAPD', () => {
       cypressLib.accesMenu('Continuous Delivery');
       cypressLib.accesMenu('Git Repos');
 
-      // Change fleet namespace
-      cy.contains('fleet-default').click();
-      cy.contains('fleet-local').click();
+      // Change namespace to fleet-local
+      cy.contains('fleet-').click();
+      cy.contains('fleet-local')
+        .should('be.visible')
+        .click();
 
       // Add CAPD fleet repository
       cy.clickButton('Add Repository');


### PR DESCRIPTION
### What does this PR do?
On fleet page, sometimes default fleet namespace in dropdown is set 'fleet-default' or 'fleet-local'. These changes selects correct namespace for our tests

### Checklist:
- [x] GitHub Actions
https://github.com/rancher-sandbox/rancher-turtles-e2e/actions/runs/7271804657
