### PR TITLE
CAPI UI Extension heading fix

### DIFF
--- a/.github/workflows/master-e2e.yaml
+++ b/.github/workflows/master-e2e.yaml
@@ -163,7 +163,7 @@ jobs:
         with:
           repository: ${{ env.TURTLES_REPO }}
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
 
@@ -181,7 +181,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version-file: tests/go.mod
       - name: Copy chart file for chartmuseum
@@ -235,7 +235,7 @@ jobs:
         run: cd tests && make start-cypress-tests
       - name: Upload Cypress screenshots (Basics)
         if: failure() 
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress-screenshots-basics-${{ inputs.cluster_name }}
           path: tests/cypress/latest/screenshots
@@ -244,7 +244,7 @@ jobs:
       - name: Upload Cypress videos (Basics)
         # Test run video is always captured, so this action uses "always()" condition
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cypress-videos-basics-${{ inputs.cluster_name }}
           path: tests/cypress/latest/videos

--- a/tests/cypress/latest/e2e/unit_tests/turtles_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/turtles_plugin.spec.ts
@@ -53,7 +53,7 @@ describe('Install CAPI plugin', () => {
       cy.clickButton('Reload');
       cy.get('.plugins')
         .children()
-        # Temporary change due to https://github.com/rancher/capi-ui-extension/issues/34
+        // Temporary change due to https://github.com/rancher/capi-ui-extension/issues/34
         .should('contain', 'UI for CAPI cluster provisioning using the Rancher Turtles extension')
         .and('contain', 'Uninstall');
     })

--- a/tests/cypress/latest/e2e/unit_tests/turtles_plugin.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/turtles_plugin.spec.ts
@@ -53,7 +53,8 @@ describe('Install CAPI plugin', () => {
       cy.clickButton('Reload');
       cy.get('.plugins')
         .children()
-        .should('contain', 'Rancher Turtles UI')
+        # Temporary change due to https://github.com/rancher/capi-ui-extension/issues/34
+        .should('contain', 'UI for CAPI cluster provisioning using the Rancher Turtles extension')
         .and('contain', 'Uninstall');
     })
   );


### PR DESCRIPTION
### What does this PR do?
Fixes failing CI for v2.7 due to Extension heading change

### Checklist:
- [x] GitHub Actions
2.7: https://github.com/rancher-sandbox/rancher-turtles-e2e/actions/runs/7785391767
2.8: https://github.com/rancher-sandbox/rancher-turtles-e2e/actions/runs/7785389824
