### PR TITLE
Enable capi-kubeadm-provider

### DIFF
--- a/tests/cypress/latest/e2e/unit_tests/capd_setup.spec.ts
+++ b/tests/cypress/latest/e2e/unit_tests/capd_setup.spec.ts
@@ -105,4 +105,36 @@ describe('Enable CAPD provider', () => {
       cy.contains('Active ' + 'docker');
     })
   );
+
+  qase(14,
+    it('Enable CAPI Kubeadm provider', () => {
+      cy.contains('local')
+        .click();
+      cypressLib.accesMenu('Projects/Namespaces');
+      cy.contains('Only User Namespaces') // eslint-disable-line cypress/unsafe-to-chain-command
+        .click()
+        .type('Not{enter}{esc}');
+
+      // Create CAPI Kubeadm provider
+      cy.get('.header-buttons > :nth-child(1) > .icon')
+        .click();
+      cy.contains('Import YAML');
+      cy.readFile('./fixtures/capi-kubeadm-provider.yaml').then((data) => {
+        cy.get('.CodeMirror')
+          .then((editor) => {
+            editor[0].CodeMirror.setValue(data);
+        })
+      })
+
+      cy.clickButton('Import')
+      cy.clickButton('Close')
+      cy.contains('Active ' + 'capi-kubeadm-bootstrap-system');
+      cy.contains('Active ' + 'capi-kubeadm-control-plane-system');
+
+      cy.getBySel('namespaces-values').click();
+      cy.contains('Only User Namespaces')
+        .click();
+    })
+  );
+
 });

--- a/tests/cypress/latest/fixtures/capi-kubeadm-provider.yaml
+++ b/tests/cypress/latest/fixtures/capi-kubeadm-provider.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-kubeadm-bootstrap-system
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: kubeadm-bootstrap
+  namespace: capi-kubeadm-bootstrap-system
+spec:
+  name: kubeadm
+  type: bootstrap
+  version: v1.4.6
+  configSecret:
+    name: variables
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: capi-kubeadm-control-plane-system
+---
+apiVersion: turtles-capi.cattle.io/v1alpha1
+kind: CAPIProvider
+metadata:
+  name: kubeadm-control-plane
+  namespace: capi-kubeadm-control-plane-system
+spec:
+  name: kubeadm
+  type: controlPlane
+  version: v1.4.6
+  configSecret:
+    name: variables


### PR DESCRIPTION
### What does this PR do?
With change introduced in https://github.com/rancher/turtles/pull/402, need to enable kubeadm provider explicitly.

### Which issue(s) this PR fixes (optional, in fixes #<issue number>(, fixes #<issue_number>, ...) format, will close the issue(s) when PR gets merged):
Fixes: Failing CI tests

### Checklist:
- [x] GitHub Actions:
https://github.com/rancher-sandbox/rancher-turtles-e2e/actions/runs/8281244103