### PR TITLE
Update AWS region and enable janitor

### DIFF
--- a/.github/workflows/janitor.yaml
+++ b/.github/workflows/janitor.yaml
@@ -1,0 +1,21 @@
+name: Janitor
+
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  aws-janitor:
+    name: aws-janitor
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    steps:
+      - name: Cleanup
+        uses: rancher-sandbox/aws-janitor@v0.1.0
+        with:
+          regions: ap-south-2
+          commit: true
+          ignore-tag: janitor-ignore

--- a/tests/assets/rancher-turtles-fleet-example/aws/clusters/cluster1.yaml
+++ b/tests/assets/rancher-turtles-fleet-example/aws/clusters/cluster1.yaml
@@ -21,7 +21,7 @@ apiVersion: controlplane.cluster.x-k8s.io/v1beta2
 metadata:
   name: "turtles-qa-cluster-control-plane"
 spec:
-  region: "ap-south-1"
+  region: "ap-south-2"
   version: "v1.28"
 ---
 apiVersion: cluster.x-k8s.io/v1beta1


### PR DESCRIPTION
### What does this PR do?
Updates AWS region for creating CAPI cluster and Enable janitor for the region, to avoid CI failures due to lack of resources eg. https://github.com/rancher-sandbox/rancher-turtles-e2e/actions/runs/8810903401

